### PR TITLE
Removing the hardcoded SettingsUrl in the SampleAlgoRunner.cs

### DIFF
--- a/src/Lykke.AlgoStore.CSharp.AlgoTemplate.API/SampleAlgoRunner.cs
+++ b/src/Lykke.AlgoStore.CSharp.AlgoTemplate.API/SampleAlgoRunner.cs
@@ -75,9 +75,6 @@ namespace Lykke.AlgoStore.CSharp.AlgoTemplate
                 .SetBasePath(Directory.GetCurrentDirectory())
                 .Build();
 
-            config.Providers.First().Set("SettingsUrl", "appsettings.Development.json");
-            config.Providers.First().Set("ASPNETCORE_ENVIRONMENT", "Development");
-
             var appSettings = config.LoadSettings<AppSettings>();
 
             var builder = new ContainerBuilder();


### PR DESCRIPTION
The issue with the current implementation is that the provided configuration is hardcoded and we are going to be unable to configure this from outside the process